### PR TITLE
Dune port: fix top-level printing.

### DIFF
--- a/top/dune
+++ b/top/dune
@@ -4,4 +4,4 @@
  (modes byte)
  (wrapped false)
  (synopsis "toplevel pretty printers")
- (libraries integers compiler-libs.toplevel))
+ (libraries integers compiler-libs))

--- a/top/install_integer_printers.ml
+++ b/top/install_integer_printers.ml
@@ -1,5 +1,7 @@
 (* Adapted from Anil Madhavapeddy's ocaml-uri package. *)
 
+let _ = Integer_printers.format_sint
+
 let printers = [ "Integer_printers.format_sint";
                  "Integer_printers.format_long";
                  "Integer_printers.format_llong";


### PR DESCRIPTION
Determine module loading order, correct compiler-libs dependency.  See https://github.com/ocamllabs/ocaml-integers/pull/21#issuecomment-445212813